### PR TITLE
refactor: remove dayjs dependency and implement custom date formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
     "axios": "^1.7.9",
-    "dayjs": "^1.11.13",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "tslog": "^3.3.4"

--- a/src/exporter/local-exporter.ts
+++ b/src/exporter/local-exporter.ts
@@ -1,4 +1,3 @@
-import * as dayjs from 'dayjs'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import {Logger} from 'tslog'
@@ -22,7 +21,7 @@ export class LocalExporter implements Exporter {
 
   async exportTestReports(testReports: TestReport[]): Promise<void> {
     await this.fs.mkdir(this.outDir, {recursive: true})
-    const outputPath = path.join(this.outDir, `${dayjs().format('YYYYMMDD-HHmm')}-test-magicpod.json`)
+    const outputPath = path.join(this.outDir, this.generateOutputFileName())
     const formated = this.formatJson(testReports)
     await this.fs.writeFile(outputPath, formated, {encoding: 'utf8'})
     this.logger.info(`Export test reports to ${outputPath}`)
@@ -38,5 +37,15 @@ export class LocalExporter implements Exporter {
         return testReports.map((report) => JSON.stringify(report)).join('\n')
       }
     }
+  }
+
+  private generateOutputFileName(): string {
+    const now = new Date()
+    const fullYear = now.getFullYear().toString().padStart(4, '0')
+    const month = (now.getMonth() + 1).toString().padStart(2, '0')
+    const date = now.getDate().toString().padStart(2, '0')
+    const hour = now.getHours().toString().padStart(2, '0')
+    const minutes  = now.getMinutes().toString().padStart(2, '0')
+    return `${fullYear}${month}${date}-${hour}${minutes}-test-magicpod.json`
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,11 +2510,6 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-dayjs@^1.11.13:
-  version "1.11.13"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.13.tgz#92430b0139055c3ebb60150aa13e860a4b5a366c"
-  integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
-
 debug@4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"


### PR DESCRIPTION
This pull request includes changes to remove the `dayjs` dependency and refactor the code to generate output file names using native JavaScript methods. The most important changes include updating the `package.json` file, modifying the `LocalExporter` class to remove `dayjs`, and adding a new method for generating output file names.

Dependency removal and refactoring:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25): Removed the `dayjs` dependency from the list of dependencies.
* [`src/exporter/local-exporter.ts`](diffhunk://#diff-2dc7d819e90984e5e488b176172f6f11870b3fe68b2b4bcd0b104a2790ca3b7fL1): Removed the import statement for `dayjs`.
* [`src/exporter/local-exporter.ts`](diffhunk://#diff-2dc7d819e90984e5e488b176172f6f11870b3fe68b2b4bcd0b104a2790ca3b7fL25-R24): Updated the `exportTestReports` method to use a new method for generating output file names instead of `dayjs`.
* [`src/exporter/local-exporter.ts`](diffhunk://#diff-2dc7d819e90984e5e488b176172f6f11870b3fe68b2b4bcd0b104a2790ca3b7fR41-R50): Added a new private method `generateOutputFileName` to generate output file names using native JavaScript `Date` methods.