### PR TITLE
refactor: replace js-yaml with yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,14 @@
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
     "axios": "^1.7.9",
-    "js-yaml": "^4.1.0",
-    "tslog": "^3.3.4"
+    "tslog": "^3.3.4",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@oclif/prettier-config": "^0.2.1",
     "@oclif/test": "^4",
     "@types/chai": "^4",
     "@types/chai-as-promised": "^7.1.8",
-    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10",
     "@types/node": "^18",
     "chai": "^4",

--- a/src/magicpod-config.ts
+++ b/src/magicpod-config.ts
@@ -1,5 +1,5 @@
-import * as yaml from 'js-yaml'
 import * as fs from 'node:fs/promises'
+import * as YAML from 'yaml'
 
 interface RawConfig {
   magicpod: {
@@ -58,7 +58,7 @@ export interface GCSLastRunStoreConfig extends LastRunStoreConfig {
 }
 
 export async function loadConfig(configPath: string): Promise<MagicPodConfig> {
-  const config = yaml.load(await fs.readFile(configPath, 'utf8')) as RawConfig
+  const config = YAML.parse(await fs.readFile(configPath, 'utf8')) as RawConfig
   const projects = config.magicpod.projects.map((project) => {
     const [organization, name] = project.split('/')
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,11 +1739,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
   integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
-"@types/js-yaml@^4.0.9":
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
-  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
-
 "@types/json-schema@^7.0.12":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -5704,6 +5699,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
+  integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
 
 yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"


### PR DESCRIPTION
This pull request includes changes to update the YAML parsing library in the project. The most important changes involve replacing the `js-yaml` library with the `yaml` library and updating the code accordingly.

Library replacement:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-L33): Removed `js-yaml` and added `yaml` as a dependency. (`[package.jsonL25-L33](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-L33)`)
* [`src/magicpod-config.ts`](diffhunk://#diff-3084aa412cfba81678b9ce74db49cc6c129529b330e2d011a1db1c41acb63695L1-R2): Replaced import of `js-yaml` with `yaml`. (`[src/magicpod-config.tsL1-R2](diffhunk://#diff-3084aa412cfba81678b9ce74db49cc6c129529b330e2d011a1db1c41acb63695L1-R2)`)
* [`src/magicpod-config.ts`](diffhunk://#diff-3084aa412cfba81678b9ce74db49cc6c129529b330e2d011a1db1c41acb63695L61-R61): Updated the `loadConfig` function to use `YAML.parse` instead of `yaml.load`. (`[src/magicpod-config.tsL61-R61](diffhunk://#diff-3084aa412cfba81678b9ce74db49cc6c129529b330e2d011a1db1c41acb63695L61-R61)`)