### PR TITLE
refactor: remove baseUrl parameters and use environment variables for configuration

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     image: mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
     volumes:
       - ../..:/workspaces:cached
-    environment:
-      - BIGQUERY_EMULATOR_HOST=http://localhost:9050
     command: sleep infinity
 
   fakepod:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,4 @@ jobs:
       - run: yarn build
       - run: yarn test
         env:
-          BIGQUERY_EMULATOR_HOST: http://localhost:9050
           NODE_TLS_REJECT_UNAUTHORIZED: 0

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,21 +36,14 @@ USAGE
 
 ```
 USAGE
-  $ magicpod-analyzer get-batch-runs --token <value> [-c <value>] [-d] [--baseUrl <value>] [--bigqueryBaseURL
-    <value>] [--gcsBaseURL <value>]
+  $ magicpod-analyzer get-batch-runs -t <value> [-c <value>] [-d]
 
 FLAGS
-  -c, --config=<value>           Config file default: magicpod_analyzer.yaml
-  -d, --debug                    Enable debug mode. You can also set this value via environment variable
-                                 `MAGICPOD_ANALYZER_DEBUG`
-      --baseUrl=<value>          Base URL for MagicPod API. You can also set this value via environment variable
-                                 `MAGICPOD_BASE_URL`
-      --bigqueryBaseURL=<value>  Base URL for BigQuery API. You can also set this value via environment variable
-                                 `BIGQUERY_BASE_URL`
-      --gcsBaseURL=<value>       Base URL for GCS API. You can also set this value via environment variable
-                                 `GCS_BASE_URL`
-      --token=<value>            (required) Access token for MagicPod API. You can also set this value via environment
-                                 variable `MAGICPOD_TOKEN`
+  -c, --config=<value>  Config file default: magicpod_analyzer.yaml
+  -d, --debug           Enable debug mode. You can also set this value via environment variable
+                        `MAGICPOD_ANALYZER_DEBUG`
+  -t, --token=<value>   (required) Access token for MagicPod API. You can also set this value via environment variable
+                        `MAGICPOD_TOKEN`
 
 DESCRIPTION
   Retrieve specified project's batch run data from MagicPod.

--- a/README.md
+++ b/README.md
@@ -38,21 +38,14 @@ Retrieve specified project's batch run data from MagicPod.
 
 ```
 USAGE
-  $ magicpod-analyzer get-batch-runs --token <value> [-c <value>] [-d] [--baseUrl <value>] [--bigqueryBaseURL
-    <value>] [--gcsBaseURL <value>]
+  $ magicpod-analyzer get-batch-runs -t <value> [-c <value>] [-d]
 
 FLAGS
-  -c, --config=<value>           Config file default: magicpod_analyzer.yaml
-  -d, --debug                    Enable debug mode. You can also set this value via environment variable
-                                 `MAGICPOD_ANALYZER_DEBUG`
-      --baseUrl=<value>          Base URL for MagicPod API. You can also set this value via environment variable
-                                 `MAGICPOD_BASE_URL`
-      --bigqueryBaseURL=<value>  Base URL for BigQuery API. You can also set this value via environment variable
-                                 `BIGQUERY_BASE_URL`
-      --gcsBaseURL=<value>       Base URL for GCS API. You can also set this value via environment variable
-                                 `GCS_BASE_URL`
-      --token=<value>            (required) Access token for MagicPod API. You can also set this value via environment
-                                 variable `MAGICPOD_TOKEN`
+  -c, --config=<value>  Config file default: magicpod_analyzer.yaml
+  -d, --debug           Enable debug mode. You can also set this value via environment variable
+                        `MAGICPOD_ANALYZER_DEBUG`
+  -t, --token=<value>   (required) Access token for MagicPod API. You can also set this value via environment variable
+                        `MAGICPOD_TOKEN`
 
 DESCRIPTION
   Retrieve specified project's batch run data from MagicPod.

--- a/src/commands/get-batch-runs.ts
+++ b/src/commands/get-batch-runs.ts
@@ -15,26 +15,13 @@ export default class GetBatchRuns extends Command {
       description:
         'Access token for MagicPod API. You can also set this value via environment variable `MAGICPOD_TOKEN`',
       env: 'MAGICPOD_TOKEN',
+      char: 't',
       required: true,
     }),
     debug: Flags.boolean({
       description: 'Enable debug mode. You can also set this value via environment variable `MAGICPOD_ANALYZER_DEBUG`',
       env: 'MAGICPOD_ANALYZER_DEBUG',
       char: 'd',
-    }),
-    baseUrl: Flags.string({
-      description:
-        'Base URL for MagicPod API. You can also set this value via environment variable `MAGICPOD_BASE_URL`',
-      env: 'MAGICPOD_BASE_URL',
-    }),
-    bigqueryBaseURL: Flags.string({
-      description:
-        'Base URL for BigQuery API. You can also set this value via environment variable `BIGQUERY_BASE_URL`',
-      env: 'BIGQUERY_BASE_URL',
-    }),
-    gcsBaseURL: Flags.string({
-      description: 'Base URL for GCS API. You can also set this value via environment variable `GCS_BASE_URL`',
-      env: 'GCS_BASE_URL',
     }),
   }
 
@@ -52,15 +39,7 @@ export default class GetBatchRuns extends Command {
     const configFile = flags.config ?? 'magicpod_analyzer.yaml'
 
     const config = await loadConfig(configFile)
-    const runner = new MagicPodRunner(
-      logger,
-      config,
-      flags.token,
-      flags.debug,
-      flags.baseUrl,
-      flags.bigqueryBaseURL,
-      flags.gcsBaseURL,
-    )
+    const runner = new MagicPodRunner(logger, config, flags.token, flags.debug)
     const result = await runner.run()
     if (result.error) {
       this.error(result.error, {exit: 1})

--- a/src/exporter/bigquery-exporter.ts
+++ b/src/exporter/bigquery-exporter.ts
@@ -19,13 +19,13 @@ export class BigqueryExporter implements Exporter {
   readonly maxBadRecords: number
   private readonly logger: Logger
 
-  constructor(logger: Logger, config: BigqueryExporterConfig, baseUrl?: string) {
+  constructor(logger: Logger, config: BigqueryExporterConfig) {
     if (!config.project || !config.dataset) {
       throw new Error("Must need 'project', 'dataset' parameter in exporter.bigquery config.")
     }
 
     this.logger = logger.getChildLogger({name: BigqueryExporter.name})
-    this.bigquery = new BigQuery({projectId: config.project, apiEndpoint: baseUrl})
+    this.bigquery = new BigQuery({projectId: config.project})
     this.dataset = config.dataset
     const testReportTable = config.reports?.find((report) => report.name === 'test_report')?.table
     if (!testReportTable) {

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -12,7 +12,7 @@ export interface Exporter {
 export class CompositExporter implements Exporter {
   readonly exporters: Exporter[]
 
-  constructor(logger: Logger, config?: ExporterConfig, debugMode = false, baseUrl?: string) {
+  constructor(logger: Logger, config?: ExporterConfig, debugMode = false) {
     if (debugMode || !config) {
       this.exporters = [new LocalExporter(logger)]
       return
@@ -24,7 +24,7 @@ export class CompositExporter implements Exporter {
     }
 
     if (config.bigquery) {
-      this.exporters.push(new BigqueryExporter(logger, config.bigquery, baseUrl))
+      this.exporters.push(new BigqueryExporter(logger, config.bigquery))
     }
   }
 

--- a/src/magicpod-client.ts
+++ b/src/magicpod-client.ts
@@ -59,7 +59,8 @@ export class MagicPodClient {
   private readonly logger: Logger
   private readonly debugMode: boolean
 
-  constructor(token: string, logger: Logger, debugMode = false, baseUrl = 'https://app.magicpod.com') {
+  constructor(token: string, logger: Logger, debugMode = false) {
+    const baseUrl = process.env.MAGICPOD_EMULATOR_HOST ?? 'https://app.magicpod.com'
     this.baseUrl = `${baseUrl}/api/v1.0`
     this.headers = {
       Authorization: `Token ${token}`,

--- a/src/store/gcs-store.ts
+++ b/src/store/gcs-store.ts
@@ -9,8 +9,7 @@ export class GcsStore implements Store {
   readonly gcsPath: string
   private readonly logger: Logger
 
-  // eslint-disable-next-line max-params
-  constructor(logger: Logger, projectId?: string, bucket?: string, filePath?: string, baseUrl?: string) {
+  constructor(logger: Logger, projectId?: string, bucket?: string, filePath?: string) {
     const fp = filePath ?? path.join('ci_analyzer', 'last_run', 'magicpod.json')
 
     if (!projectId || !bucket) {
@@ -19,7 +18,7 @@ export class GcsStore implements Store {
 
     this.logger = logger.getChildLogger({name: GcsStore.name})
 
-    const storage = new Storage({projectId, apiEndpoint: baseUrl})
+    const storage = new Storage({projectId, apiEndpoint: process.env.GCS_EMULATOR_HOST})
     this.file = storage.bucket(bucket).file(fp)
     this.gcsPath = `gs://${bucket}/${fp}`
   }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -21,12 +21,7 @@ export class LastRunStore {
   readonly store: Store
   private lastRun: LastRun
 
-  static async init(
-    logger: Logger,
-    config: LastRunStoreConfig,
-    debugMode = false,
-    baseUrl?: string,
-  ): Promise<LastRunStore> {
+  static async init(logger: Logger, config: LastRunStoreConfig, debugMode = false): Promise<LastRunStore> {
     let store
     if (debugMode) {
       store = new NullStore(logger)
@@ -36,7 +31,7 @@ export class LastRunStore {
       store = new LocalStore(logger, (config as LocalLastRunStoreConfig).path)
     } else if (config.backend === 'gcs') {
       const _config = config as GCSLastRunStoreConfig
-      store = new GcsStore(logger, _config.project, _config.bucket, _config.path, baseUrl)
+      store = new GcsStore(logger, _config.project, _config.bucket, _config.path)
     } else {
       throw new Error(`Error: Unknown LastRunStore.backend type '${config.backend}'`)
     }

--- a/test/commands/get-batch-runs.test.ts
+++ b/test/commands/get-batch-runs.test.ts
@@ -38,7 +38,7 @@ describe('get-batch-runs', () => {
     // Set environment variables
     originalEnv = {...process.env}
     process.env = {
-      ...process.env,
+      ...originalEnv,
       MAGICPOD_EMULATOR_HOST: MAGICPOD_FOR_TEST,
       GCS_EMULATOR_HOST: GCS_FOR_TEST,
       BIGQUERY_EMULATOR_HOST: BIGQUERY_FOR_TEST,

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -15,6 +15,21 @@ const {expect} = chai
 const GCS_FOR_TEST = process.env.GITHUB_ACTIONS ? 'https://localhost:4443' : 'http://localhost:4443'
 
 describe('store', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(async () => {
+    // Set environment variables
+    originalEnv = {...process.env}
+    process.env = {
+      ...process.env,
+      GCS_EMULATOR_HOST: GCS_FOR_TEST,
+    }
+  })
+
+  afterEach(async () => {
+    process.env = originalEnv
+  })
+
   it('initialize', async () => {
     let config = {backend: 'local', filePath: 'test.json'} as LastRunStoreConfig
     const nullStore = await LastRunStore.init(new Logger(), config, true)
@@ -22,7 +37,7 @@ describe('store', () => {
     const localStore = await LastRunStore.init(new Logger(), config)
     expect(localStore.store).to.be.instanceOf(LocalStore)
     config = {backend: 'gcs', project: 'fake-project', bucket: 'fake-bucket', path: 'test.json'} as LastRunStoreConfig
-    const gcsStore = await LastRunStore.init(new Logger(), config, false, GCS_FOR_TEST)
+    const gcsStore = await LastRunStore.init(new Logger(), config, false)
     expect(gcsStore.store).to.be.instanceOf(GcsStore)
   })
 })

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -21,7 +21,7 @@ describe('store', () => {
     // Set environment variables
     originalEnv = {...process.env}
     process.env = {
-      ...process.env,
+      ...originalEnv,
       GCS_EMULATOR_HOST: GCS_FOR_TEST,
     }
   })


### PR DESCRIPTION
This pull request includes several changes to remove the use of base URLs from the configuration and improve environment variable handling. The changes primarily focus on simplifying the configuration and command-line interface for the `magicpod-analyzer` tool.

### Configuration and Command-Line Interface Simplification:

* Removed base URL flags and environment variables from the `magicpod-analyzer` command usage in `README.md` and `README.ja.md`. Updated the token flag to use `-t` instead of `--token`. [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L39-R46) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R48)
* Removed base URL-related flags from the `GetBatchRuns` command in `src/commands/get-batch-runs.ts`. [[1]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81R18-L38) [[2]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81L55-R42)

### Codebase Refactoring:

* Updated the `MagicPodClient` and `MagicPodRunner` classes to set the base URL using an environment variable `MAGICPOD_EMULATOR_HOST` and removed the base URL parameter from their constructors. [[1]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L62-R63) [[2]](diffhunk://#diff-7d749cb851f4bf443cfbf77df55c5eec3dadd1a3cae0fe23dd1badaa02f2d713L21-R36) [[3]](diffhunk://#diff-7d749cb851f4bf443cfbf77df55c5eec3dadd1a3cae0fe23dd1badaa02f2d713L82-R69)
* Updated the `BigqueryExporter` and `GcsStore` classes to remove the base URL parameter from their constructors. [[1]](diffhunk://#diff-a0bec27641c1f7506777bce3bdce95f830bf58f63de9b8ba87fd8b60f10ac843L22-R28) [[2]](diffhunk://#diff-9e9531d666e8bb821d60202debe4c4681f5e10c172e77c2345a8382945d618c8L12-R12) [[3]](diffhunk://#diff-9e9531d666e8bb821d60202debe4c4681f5e10c172e77c2345a8382945d618c8L22-R21)

### Testing Enhancements:

* Added environment variable setup and teardown in the test files to ensure proper configuration during tests. [[1]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6R16-R24) [[2]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6R38-R46) [[3]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6R72-R74) [[4]](diffhunk://#diff-cd5a5bb6c9c390eceb05a13e202a560a3f030b2dd1815e7496f6226d85240cabR18-R40)
* Removed base URL parameters from test commands in `get-batch-runs.test.ts`. [[1]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6L69-L74) [[2]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6L103-L108) [[3]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6L141-L147) [[4]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6L178-L183) [[5]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6L196-L201) [[6]](diffhunk://#diff-d5860198b2af8cbcff5c3da520a45be774d710345ccd18b915e96261f0b97af6L215-L220)