### PR TITLE
refactor: implement custom maxBy and minBy functions in util module

### DIFF
--- a/src/commands/get-batch-runs.ts
+++ b/src/commands/get-batch-runs.ts
@@ -7,6 +7,7 @@ import {MagicPodAnalyzer, TestReport} from '../magicpod-analyzer'
 import {MagicPodClient} from '../magicpod-client'
 import {loadConfig} from '../magicpod-config'
 import {LastRunStore} from '../store/store'
+import {maxBy} from '../util'
 
 interface Result {
   status: 'success' | 'failure'
@@ -70,7 +71,7 @@ export default class GetBatchRuns extends Command {
 
         // store
         if (reports.length > 0) {
-          const lastRunReport = this.maxBy(reports, (report) => report.buildNumber)
+          const lastRunReport = maxBy(reports, (report) => report.buildNumber)
           if (lastRunReport) {
             store.setLastRun(project.fullName, lastRunReport.buildNumber)
           }
@@ -98,10 +99,5 @@ export default class GetBatchRuns extends Command {
     } else {
       this.exit()
     }
-  }
-
-  private maxBy<T>(collection: T[], iteratee: (item: T) => number): T | undefined {
-    const max = Math.max(...collection.map((item) => iteratee(item)))
-    return collection.find((item) => iteratee(item) === max)
   }
 }

--- a/src/magicpod-client.ts
+++ b/src/magicpod-client.ts
@@ -1,5 +1,7 @@
 import {Logger} from 'tslog'
 
+import {minBy} from './util'
+
 type Status = 'not-running' | 'running' | 'succeeded' | 'failed' | 'aborted' | 'unresolved'
 
 export interface BatchRuns {
@@ -90,7 +92,7 @@ export class MagicPodClient {
     const batchRuns = (await response.json()) as BatchRuns
 
     // Cut running data
-    const firstInprogress = this.minBy(
+    const firstInprogress = minBy(
       batchRuns.batch_runs.filter((batchRun) => batchRun.status === 'running' || batchRun.status === 'unresolved'),
       (batchRun) => batchRun.batch_run_number,
     )
@@ -119,11 +121,6 @@ export class MagicPodClient {
       batch_runs: resultBatchRuns,
     }
     /* eslint-enable camelcase */
-  }
-
-  private minBy<T>(collection: T[], iteratee: (item: T) => number): T | undefined {
-    const min = Math.min(...collection.map((item) => iteratee(item)))
-    return collection.find((item) => iteratee(item) === min)
   }
 
   private async fetchWithLogging(request: Request): Promise<Response> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,9 @@
+export function maxBy<T>(collection: T[], iteratee: (item: T) => number): T | undefined {
+  const max = Math.max(...collection.map((item) => iteratee(item)))
+  return collection.find((item) => iteratee(item) === max)
+}
+
+export function minBy<T>(collection: T[], iteratee: (item: T) => number): T | undefined {
+  const min = Math.min(...collection.map((item) => iteratee(item)))
+  return collection.find((item) => iteratee(item) === min)
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,49 @@
+import * as chai from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
+
+import {maxBy, minBy} from '../src/util'
+
+chai.use(chaiAsPromised)
+
+const {expect} = chai
+
+interface Item {
+  name: string,
+  value: number,
+}
+
+describe('util', () => {
+  describe('maxBy', () => {
+    it('should return the max value', () => {
+      const collection: Item[] = [{name: 'a', value: 1}, {name: 'b', value: 2}, {name: 'c', value: 3}, {name: 'd', value: 4}, {name: 'e', value: 5}]
+      expect(maxBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'e', value: 5})
+    })
+
+    it('should return the first max value', () => {
+      const collection: Item[] = [{name: 'a', value: 1}, {name: 'b', value: 5}, {name: 'c', value: 3}, {name: 'd', value: 5}, {name: 'e', value: 5}]
+      expect(maxBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'b', value: 5})
+    })
+
+    it('should return undefined when collection is empty', () => {
+      const collection: Item[] = []
+      expect(maxBy(collection, (item: Item) => item.value)).to.be.undefined
+    })
+  })
+
+  describe('minBy', () => {
+    it('should return the min value', () => {
+      const collection: Item[] = [{name: 'a', value: 1}, {name: 'b', value: 2}, {name: 'c', value: 3}, {name: 'd', value: 4}, {name: 'e', value: 5}]
+      expect(minBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'a', value: 1})
+    })
+
+    it('should return the first min value', () => {
+      const collection: Item[] = [{name: 'a', value: 5}, {name: 'b', value: 3}, {name: 'c', value: 1}, {name: 'd', value: 3}, {name: 'e', value: 1}]
+      expect(minBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'c', value: 1})
+    })
+
+    it('should return undefined when collection is empty', () => {
+      const collection: Item[] = []
+      expect(minBy(collection, (item: Item) => item.value)).to.be.undefined
+    })
+  })
+})


### PR DESCRIPTION
This pull request focuses on refactoring utility functions and improving test coverage. The main changes involve moving `maxBy` and `minBy` functions to a utility file and adding tests for these functions. Additionally, the usage of these functions has been updated in relevant files.

Refactoring utility functions:

* [`src/commands/get-batch-runs.ts`](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81R10): Removed the `maxBy` method from the `GetBatchRuns` class and replaced its usage with the imported `maxBy` function from `src/util.ts`. [[1]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81R10) [[2]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81L73-R74) [[3]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81L102-L106)
* [`src/magicpod-client.ts`](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249R3-R4): Removed the `minBy` method from the `MagicPodClient` class and replaced its usage with the imported `minBy` function from `src/util.ts`. [[1]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249R3-R4) [[2]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L93-R95) [[3]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L124-L128)
* [`src/util.ts`](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R1-R9): Added the `maxBy` and `minBy` functions to this utility file.

Improving test coverage:

* [`test/util.test.ts`](diffhunk://#diff-7aca83012b206780c7a11ab5aa96f9282ea3f4677763e664a94836a97fb78219R1-R49): Added unit tests for the `maxBy` and `minBy` functions to ensure they work as expected.