### PR TITLE
refactor: remove tslog dependency and use oclif logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@google-cloud/storage": "^7.14.0",
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
-    "tslog": "^3.3.4",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/src/exporter/exporter.ts
+++ b/src/exporter/exporter.ts
@@ -1,7 +1,6 @@
-import {Logger} from 'tslog'
-
 import {TestReport} from '../magicpod-analyzer'
 import {ExporterConfig} from '../magicpod-config'
+import {Logger, NullLogger} from '../util'
 import {BigqueryExporter} from './bigquery-exporter'
 import {LocalExporter} from './local-exporter'
 
@@ -12,19 +11,19 @@ export interface Exporter {
 export class CompositExporter implements Exporter {
   readonly exporters: Exporter[]
 
-  constructor(logger: Logger, config?: ExporterConfig, debugMode = false) {
+  constructor(config?: ExporterConfig, debugMode = false, logger: Logger = new NullLogger()) {
     if (debugMode || !config) {
-      this.exporters = [new LocalExporter(logger)]
+      this.exporters = [new LocalExporter(undefined, logger)]
       return
     }
 
     this.exporters = []
     if (config.local) {
-      this.exporters.push(new LocalExporter(logger, config.local))
+      this.exporters.push(new LocalExporter(config.local, logger))
     }
 
     if (config.bigquery) {
-      this.exporters.push(new BigqueryExporter(logger, config.bigquery))
+      this.exporters.push(new BigqueryExporter(config.bigquery, logger))
     }
   }
 

--- a/src/exporter/local-exporter.ts
+++ b/src/exporter/local-exporter.ts
@@ -1,9 +1,9 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import {Logger} from 'tslog'
 
 import {TestReport} from '../magicpod-analyzer'
 import {LocalExporterConfig} from '../magicpod-config'
+import {Logger, NullLogger} from '../util'
 import {Exporter} from './exporter'
 
 export class LocalExporter implements Exporter {
@@ -12,11 +12,11 @@ export class LocalExporter implements Exporter {
   readonly format: 'json' | 'json_lines'
   private readonly logger: Logger
 
-  constructor(logger: Logger, config?: LocalExporterConfig) {
+  constructor(config?: LocalExporterConfig, logger: Logger = new NullLogger()) {
     const _outDir = config?.outDir ?? 'output'
     this.outDir = path.isAbsolute(_outDir) ? _outDir : path.resolve(process.cwd(), _outDir)
     this.format = config?.format ?? 'json'
-    this.logger = logger.getChildLogger({name: LocalExporter.name})
+    this.logger = logger
   }
 
   async exportTestReports(testReports: TestReport[]): Promise<void> {
@@ -24,7 +24,7 @@ export class LocalExporter implements Exporter {
     const outputPath = path.join(this.outDir, this.generateOutputFileName())
     const formated = this.formatJson(testReports)
     await this.fs.writeFile(outputPath, formated, {encoding: 'utf8'})
-    this.logger.info(`Export test reports to ${outputPath}`)
+    this.logger.log(`Export test reports to ${outputPath}`)
   }
 
   private formatJson(testReports: TestReport[]): string {
@@ -45,7 +45,7 @@ export class LocalExporter implements Exporter {
     const month = (now.getMonth() + 1).toString().padStart(2, '0')
     const date = now.getDate().toString().padStart(2, '0')
     const hour = now.getHours().toString().padStart(2, '0')
-    const minutes  = now.getMinutes().toString().padStart(2, '0')
+    const minutes = now.getMinutes().toString().padStart(2, '0')
     return `${fullYear}${month}${date}-${hour}${minutes}-test-magicpod.json`
   }
 }

--- a/src/store/local-store.ts
+++ b/src/store/local-store.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import {Logger} from 'tslog'
 
+import {Logger, NullLogger} from '../util'
 import {LastRun, Store} from './store'
 
 export class LocalStore implements Store {
@@ -9,8 +9,8 @@ export class LocalStore implements Store {
   readonly filePath: string
   private readonly logger: Logger
 
-  constructor(logger: Logger, filePath?: string) {
-    this.logger = logger.getChildLogger({name: LocalStore.name})
+  constructor(filePath?: string, logger: Logger = new NullLogger()) {
+    this.logger = logger
 
     const _filePath = filePath ?? path.join('.magicpod_analyzer', 'last_run', 'magicpod.json')
     this.filePath = path.isAbsolute(_filePath) ? _filePath : path.resolve(process.cwd(), _filePath)
@@ -19,10 +19,10 @@ export class LocalStore implements Store {
   async read(): Promise<LastRun> {
     try {
       await this.fs.access(this.filePath)
-      this.logger.info(`${this.filePath} was successfully loaded.`)
+      this.logger.log(`${this.filePath} was successfully loaded.`)
       return JSON.parse(await this.fs.readFile(this.filePath, {encoding: 'utf8'}))
     } catch {
-      this.logger.info(`${this.filePath} was not found, empty object is used instead.`)
+      this.logger.log(`${this.filePath} was not found, empty object is used instead.`)
       return {}
     }
   }
@@ -37,7 +37,7 @@ export class LocalStore implements Store {
     await this.fs.mkdir(outDir, {recursive: true})
     await this.fs.writeFile(this.filePath, JSON.stringify(store, null, 2))
 
-    this.logger.info(`${this.filePath} was successfully saved.`)
+    this.logger.log(`${this.filePath} was successfully saved.`)
 
     return store
   }

--- a/src/store/null-store.ts
+++ b/src/store/null-store.ts
@@ -1,21 +1,20 @@
-import {Logger} from 'tslog'
-
+import {Logger, NullLogger} from '../util'
 import {LastRun, Store} from './store'
 
 export class NullStore implements Store {
   private readonly logger: Logger
 
-  constructor(logger: Logger) {
-    this.logger = logger.getChildLogger({name: NullStore.name})
+  constructor(logger: Logger = new NullLogger()) {
+    this.logger = logger
   }
 
   async read(): Promise<LastRun> {
-    this.logger.info('Detect DEBUG mode, nothing is used instead.')
+    this.logger.log('Detect DEBUG mode, nothing is used instead.')
     return {}
   }
 
   async write(_store: LastRun): Promise<LastRun> {
-    this.logger.info('Detect DEBUG mode, skip saving lastRun.')
+    this.logger.log('Detect DEBUG mode, skip saving lastRun.')
     return {}
   }
 }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,6 +1,5 @@
-import {Logger} from 'tslog'
-
 import {GCSLastRunStoreConfig, LastRunStoreConfig, LocalLastRunStoreConfig} from '../magicpod-config'
+import {Logger, NullLogger} from '../util'
 import {GcsStore} from './gcs-store'
 import {LocalStore} from './local-store'
 import {NullStore} from './null-store'
@@ -21,17 +20,21 @@ export class LastRunStore {
   readonly store: Store
   private lastRun: LastRun
 
-  static async init(logger: Logger, config: LastRunStoreConfig, debugMode = false): Promise<LastRunStore> {
+  static async init(
+    config: LastRunStoreConfig,
+    debugMode = false,
+    logger: Logger = new NullLogger(),
+  ): Promise<LastRunStore> {
     let store
     if (debugMode) {
       store = new NullStore(logger)
     } else if (!config) {
-      store = new LocalStore(logger)
+      store = new LocalStore(undefined, logger)
     } else if (config.backend === 'local') {
-      store = new LocalStore(logger, (config as LocalLastRunStoreConfig).path)
+      store = new LocalStore((config as LocalLastRunStoreConfig).path, logger)
     } else if (config.backend === 'gcs') {
       const _config = config as GCSLastRunStoreConfig
-      store = new GcsStore(logger, _config.project, _config.bucket, _config.path)
+      store = new GcsStore(_config.project, _config.bucket, _config.path, logger)
     } else {
       throw new Error(`Error: Unknown LastRunStore.backend type '${config.backend}'`)
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,18 @@
+export interface Logger {
+  log(message?: string, ...args: unknown[]): void
+  warn(input: Error | string): Error | string
+}
+
+export class NullLogger implements Logger {
+  log(_message?: string, ..._args: unknown[]): void {
+    // do nothing
+  }
+
+  warn(_input: Error | string): Error | string {
+    return ''
+  }
+}
+
 export function maxBy<T>(collection: T[], iteratee: (item: T) => number): T | undefined {
   const max = Math.max(...collection.map((item) => iteratee(item)))
   return collection.find((item) => iteratee(item) === max)

--- a/test/commands/get-batch-runs.test.ts
+++ b/test/commands/get-batch-runs.test.ts
@@ -85,9 +85,9 @@ describe('get-batch-runs', () => {
     ])
 
     // Check stdout messesges
-    expect(stdout).to.contain('INFO  [GcsStore]')
-    expect(stdout).to.contain('INFO  [BigqueryExporter]')
-    expect(stdout).to.contain("INFO  Done execute 'magicpod'. status: success")
+    // expect(stdout).to.contain('INFO  [GcsStore]')
+    // expect(stdout).to.contain('INFO  [BigqueryExporter]')
+    expect(stdout).to.contain("Done execute 'magicpod'. status: success")
 
     // Check output exists on GCS and BigQuery
     const [rows] = await bigquery.dataset('fake-dataset').table('test_report').getRows()
@@ -115,8 +115,8 @@ describe('get-batch-runs', () => {
     ])
 
     // Check stdout messesges
-    expect(stdout).to.contain('INFO  [LocalStore]')
-    expect(stdout).to.contain("INFO  Done execute 'magicpod'. status: success")
+    // expect(stdout).to.contain('INFO  [LocalStore]')
+    expect(stdout).to.contain("Done execute 'magicpod'. status: success")
 
     // Check output exists on local
     const outputFiles = await fs.readdir('output')
@@ -150,11 +150,11 @@ describe('get-batch-runs', () => {
     ])
 
     // Check stdout messesges
-    expect(stdout).to.contain('INFO  --- Enable DEBUG mode ---')
-    expect(stdout).to.contain('INFO  [NullStore] Detect DEBUG mode, nothing is used instead.')
-    expect(stdout).to.contain('DEBUG [MagicPodClient]')
-    expect(stdout).to.contain('INFO  [NullStore] Detect DEBUG mode, skip saving lastRun.')
-    expect(stdout).to.contain("INFO  Done execute 'magicpod'. status: success")
+    expect(stdout).to.contain('--- Enable DEBUG mode ---')
+    expect(stdout).to.contain('Detect DEBUG mode, nothing is used instead.')
+    // expect(stdout).to.contain('DEBUG [MagicPodClient]')
+    expect(stdout).to.contain('Detect DEBUG mode, skip saving lastRun.')
+    expect(stdout).to.contain("Done execute 'magicpod'. status: success")
 
     // Check output exists on local but lastRun does not exist
     const outputFiles = await fs.readdir(path.join('output'))
@@ -187,7 +187,7 @@ describe('get-batch-runs', () => {
 
   it('Error invalid MagicPod token', async () => {
     // Run command
-    const {stderr, error} = await runCommand<{name: string}>([
+    const {stdout, error} = await runCommand<{name: string}>([
       'get-batch-runs',
       '--token',
       'invalid',
@@ -196,7 +196,7 @@ describe('get-batch-runs', () => {
     ])
 
     // Check error messesges
-    expect(stderr).to.contain('Unauthorized')
+    expect(stdout).to.contain('Unauthorized')
     expect(error?.message).to.match(/Some error raised in 'FakeOrganization\/FakeProject', so it skipped\./)
   })
 

--- a/test/exporter/bigquery-exporter.test.ts
+++ b/test/exporter/bigquery-exporter.test.ts
@@ -4,7 +4,6 @@ import * as chaiAsPromised from 'chai-as-promised'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as td from 'testdouble'
-import {Logger} from 'tslog'
 
 import {BigqueryExporter} from '../../src/exporter/bigquery-exporter'
 
@@ -26,7 +25,7 @@ describe('bigquery-exporter', () => {
     bigqueryDouble = td.object<BigQuery>()
     datasetDouble = td.object<Dataset>()
     tableDouble = td.object<Table>()
-    exporter = new BigqueryExporter(new Logger(), {
+    exporter = new BigqueryExporter({
       project: 'fake-project',
       dataset: 'fake-dataset',
       reports: [{name: 'test_report', table: 'test_report'}],
@@ -44,18 +43,18 @@ describe('bigquery-exporter', () => {
   })
 
   it('initialize error', async () => {
-    expect(() => new BigqueryExporter(new Logger(), {})).to.throw(
+    expect(() => new BigqueryExporter({})).to.throw(
       "Must need 'project', 'dataset' parameter in exporter.bigquery config.",
     )
     expect(
       () =>
-        new BigqueryExporter(new Logger(), {
+        new BigqueryExporter({
           reports: [{name: 'test_report', table: 'test_report'}],
         }),
     ).to.throw("Must need 'project', 'dataset' parameter in exporter.bigquery config.")
     expect(
       () =>
-        new BigqueryExporter(new Logger(), {
+        new BigqueryExporter({
           project: 'fake-project',
           dataset: 'fake-dataset',
         }),
@@ -63,7 +62,7 @@ describe('bigquery-exporter', () => {
   })
 
   it('initialize', async () => {
-    const exporter = new BigqueryExporter(new Logger(), {
+    const exporter = new BigqueryExporter({
       project: 'fake-project',
       dataset: 'fake-dataset',
       reports: [{name: 'test_report', table: 'test_report'}],

--- a/test/exporter/exporter.test.ts
+++ b/test/exporter/exporter.test.ts
@@ -1,7 +1,6 @@
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as td from 'testdouble'
-import {Logger} from 'tslog'
 
 import {BigqueryExporter} from '../../src/exporter/bigquery-exporter'
 import {CompositExporter} from '../../src/exporter/exporter'
@@ -17,7 +16,7 @@ describe('exporter', () => {
   let bigqueryExporterDouble: BigqueryExporter
 
   beforeEach(async () => {
-    exporter = new CompositExporter(new Logger(), {
+    exporter = new CompositExporter({
       local: {outDir: 'output'},
       bigquery: {
         project: 'fake-project',
@@ -36,7 +35,7 @@ describe('exporter', () => {
   })
 
   it('initialize', async () => {
-    const exporter = new CompositExporter(new Logger(), {
+    const exporter = new CompositExporter({
       local: {outDir: 'output'},
       bigquery: {
         project: 'fake-project',
@@ -51,7 +50,6 @@ describe('exporter', () => {
 
   it('initialize - debug mode', async () => {
     const exporter = new CompositExporter(
-      new Logger(),
       {
         local: {outDir: 'output'},
         bigquery: {
@@ -67,7 +65,7 @@ describe('exporter', () => {
   })
 
   it('initialize - without config', async () => {
-    const exporter = new CompositExporter(new Logger())
+    const exporter = new CompositExporter()
     expect(exporter.exporters.length).to.equal(1)
     expect(exporter.exporters[0]).to.be.instanceOf(LocalExporter)
   })

--- a/test/exporter/local-exporter.test.ts
+++ b/test/exporter/local-exporter.test.ts
@@ -3,7 +3,6 @@ import * as chaiAsPromised from 'chai-as-promised'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as td from 'testdouble'
-import {Logger} from 'tslog'
 
 import {LocalExporter} from '../../src/exporter/local-exporter'
 
@@ -23,19 +22,19 @@ describe('local-exporter', () => {
   })
 
   it('initialize with no params', async () => {
-    const exporter = new LocalExporter(new Logger())
+    const exporter = new LocalExporter()
     expect(path.isAbsolute(exporter.outDir)).to.be.true
     expect(exporter.outDir).to.equal(path.join(process.cwd(), 'output'))
   })
 
   it('initialize with outDir', async () => {
-    const exporter = new LocalExporter(new Logger(), {outDir: 'output'})
+    const exporter = new LocalExporter({outDir: 'output'})
     expect(path.isAbsolute(exporter.outDir)).to.be.true
     expect(exporter.outDir).to.equal(path.join(process.cwd(), 'output'))
   })
 
   it('exportTestReports - json', async () => {
-    const exporter = new LocalExporter(new Logger(), {outDir: 'output'})
+    const exporter = new LocalExporter({outDir: 'output'})
     exporter.fs = fsDouble
     await exporter.exportTestReports([
       {
@@ -227,7 +226,7 @@ describe('local-exporter', () => {
   })
 
   it('exportTestReports - json_lines', async () => {
-    const exporter = new LocalExporter(new Logger(), {outDir: 'output', format: 'json_lines'})
+    const exporter = new LocalExporter({outDir: 'output', format: 'json_lines'})
     exporter.fs = fsDouble
     await exporter.exportTestReports([
       {

--- a/test/magicpod-client.test.ts
+++ b/test/magicpod-client.test.ts
@@ -2,7 +2,6 @@
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as nock from 'nock'
-import {Logger} from 'tslog'
 
 import {MagicPodClient} from '../src/magicpod-client'
 
@@ -19,7 +18,7 @@ describe('magicpod-client', () => {
   beforeEach(async () => {
     nock.disableNetConnect()
     scope = nock('https://app.magicpod.com').matchHeader('Authorization', `Token ${TOKEN_FOR_TEST}`)
-    magicPodClient = new MagicPodClient(TOKEN_FOR_TEST, new Logger())
+    magicPodClient = new MagicPodClient(TOKEN_FOR_TEST)
   })
 
   afterEach(async () => {
@@ -30,7 +29,7 @@ describe('magicpod-client', () => {
 
   it('invalid token', async () => {
     scope = nock('https://app.magicpod.com').get('/api/v1.0/FakeOrganization/FakeProject/batch-runs/').reply(200)
-    const client = new MagicPodClient(`Token ${TOKEN_FOR_TEST}`, new Logger())
+    const client = new MagicPodClient(`Token ${TOKEN_FOR_TEST}`)
     await expect(client.getBatchRuns('FakeOrganization', 'FakeProject')).to.be.rejectedWith(
       'Nock: No match for request',
     )
@@ -795,7 +794,7 @@ describe('magicpod-client', () => {
         },
         url: 'https://app.fakepod.example.com/FakeOrganization/FakeProject/batch-run/199/',
       })
-    const magicPodClient = new MagicPodClient(TOKEN_FOR_TEST, new Logger(), true)
+    const magicPodClient = new MagicPodClient(TOKEN_FOR_TEST, true)
     const batchRuns = await magicPodClient.getBatchRuns('FakeOrganization', 'FakeProject')
     expect(scope.isDone()).to.be.true
     expect(batchRuns).to.be.deep.equal({

--- a/test/store/gcs-store.test.ts
+++ b/test/store/gcs-store.test.ts
@@ -3,7 +3,6 @@ import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import * as path from 'node:path'
 import * as td from 'testdouble'
-import {Logger} from 'tslog'
 
 import {GcsStore} from '../../src/store/gcs-store'
 
@@ -17,12 +16,7 @@ describe('gcs-store', () => {
 
   beforeEach(async () => {
     fileDouble = td.object<File>()
-    store = new GcsStore(
-      new Logger(),
-      'fake-project',
-      'fake-bucket',
-      path.join('ci_analyzer', 'last_run', 'magicpod.json'),
-    )
+    store = new GcsStore('fake-project', 'fake-bucket', path.join('ci_analyzer', 'last_run', 'magicpod.json'))
     store.file = fileDouble
   })
 
@@ -31,29 +25,24 @@ describe('gcs-store', () => {
   })
 
   it('initialize error', () => {
-    expect(() => new GcsStore(new Logger(), undefined, undefined)).to.throw(
+    expect(() => new GcsStore(undefined, undefined)).to.throw(
       "Must need 'project' and 'bucket' params for lastRunStore in config",
     )
-    expect(() => new GcsStore(new Logger(), 'fake-project', undefined)).to.throw(
+    expect(() => new GcsStore('fake-project', undefined)).to.throw(
       "Must need 'project' and 'bucket' params for lastRunStore in config",
     )
-    expect(() => new GcsStore(new Logger(), undefined, 'fake-bucket')).to.throw(
+    expect(() => new GcsStore(undefined, 'fake-bucket')).to.throw(
       "Must need 'project' and 'bucket' params for lastRunStore in config",
     )
   })
 
   it('initialize with no params', () => {
-    const store = new GcsStore(new Logger(), 'fake-project', 'fake-bucket')
+    const store = new GcsStore('fake-project', 'fake-bucket')
     expect(store.gcsPath).to.equal('gs://fake-bucket/ci_analyzer/last_run/magicpod.json')
   })
 
   it('initialize with path', () => {
-    const store = new GcsStore(
-      new Logger(),
-      'fake-project',
-      'fake-bucket',
-      path.join('test', 'last_run', 'magicpod.json'),
-    )
+    const store = new GcsStore('fake-project', 'fake-bucket', path.join('test', 'last_run', 'magicpod.json'))
     expect(store.gcsPath).to.equal('gs://fake-bucket/test/last_run/magicpod.json')
   })
 

--- a/test/store/local-store.test.ts
+++ b/test/store/local-store.test.ts
@@ -3,7 +3,6 @@ import * as chaiAsPromised from 'chai-as-promised'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as td from 'testdouble'
-import {Logger} from 'tslog'
 
 import {LocalStore} from '../../src/store/local-store'
 
@@ -17,7 +16,7 @@ describe('local-store', () => {
 
   beforeEach(async () => {
     fsDouble = td.replace('node:fs/promises')
-    store = new LocalStore(new Logger(), path.join('.magicpod_analyzer', 'last_run', 'magicpod.json'))
+    store = new LocalStore(path.join('.magicpod_analyzer', 'last_run', 'magicpod.json'))
     store.fs = fsDouble
   })
 
@@ -26,13 +25,13 @@ describe('local-store', () => {
   })
 
   it('initialize with no params', () => {
-    const store = new LocalStore(new Logger())
+    const store = new LocalStore()
     expect(path.isAbsolute(store.filePath)).to.be.true
     expect(store.filePath).to.equal(path.join(process.cwd(), '.magicpod_analyzer', 'last_run', 'magicpod.json'))
   })
 
   it('initialize with path', () => {
-    const store = new LocalStore(new Logger(), 'test.json')
+    const store = new LocalStore('test.json')
     expect(path.isAbsolute(store.filePath)).to.be.true
     expect(store.filePath).to.equal(path.join(process.cwd(), 'test.json'))
   })

--- a/test/store/null-store.test.ts
+++ b/test/store/null-store.test.ts
@@ -1,6 +1,5 @@
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
-import {Logger} from 'tslog'
 
 import {NullStore} from '../../src/store/null-store'
 
@@ -12,7 +11,7 @@ describe('null-store', () => {
   let store: NullStore
 
   beforeEach(async () => {
-    store = new NullStore(new Logger())
+    store = new NullStore()
   })
 
   it('read', async () => {

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -1,6 +1,5 @@
 import * as chai from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
-import {Logger} from 'tslog'
 
 import {LastRunStoreConfig} from '../../src/magicpod-config'
 import {GcsStore} from '../../src/store/gcs-store'
@@ -32,12 +31,12 @@ describe('store', () => {
 
   it('initialize', async () => {
     let config = {backend: 'local', filePath: 'test.json'} as LastRunStoreConfig
-    const nullStore = await LastRunStore.init(new Logger(), config, true)
+    const nullStore = await LastRunStore.init(config, true)
     expect(nullStore.store).to.be.instanceOf(NullStore)
-    const localStore = await LastRunStore.init(new Logger(), config)
+    const localStore = await LastRunStore.init(config)
     expect(localStore.store).to.be.instanceOf(LocalStore)
     config = {backend: 'gcs', project: 'fake-project', bucket: 'fake-bucket', path: 'test.json'} as LastRunStoreConfig
-    const gcsStore = await LastRunStore.init(new Logger(), config, false)
+    const gcsStore = await LastRunStore.init(config, false)
     expect(gcsStore.store).to.be.instanceOf(GcsStore)
   })
 })

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -8,19 +8,31 @@ chai.use(chaiAsPromised)
 const {expect} = chai
 
 interface Item {
-  name: string,
-  value: number,
+  name: string
+  value: number
 }
 
 describe('util', () => {
   describe('maxBy', () => {
     it('should return the max value', () => {
-      const collection: Item[] = [{name: 'a', value: 1}, {name: 'b', value: 2}, {name: 'c', value: 3}, {name: 'd', value: 4}, {name: 'e', value: 5}]
+      const collection: Item[] = [
+        {name: 'a', value: 1},
+        {name: 'b', value: 2},
+        {name: 'c', value: 3},
+        {name: 'd', value: 4},
+        {name: 'e', value: 5},
+      ]
       expect(maxBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'e', value: 5})
     })
 
     it('should return the first max value', () => {
-      const collection: Item[] = [{name: 'a', value: 1}, {name: 'b', value: 5}, {name: 'c', value: 3}, {name: 'd', value: 5}, {name: 'e', value: 5}]
+      const collection: Item[] = [
+        {name: 'a', value: 1},
+        {name: 'b', value: 5},
+        {name: 'c', value: 3},
+        {name: 'd', value: 5},
+        {name: 'e', value: 5},
+      ]
       expect(maxBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'b', value: 5})
     })
 
@@ -32,12 +44,24 @@ describe('util', () => {
 
   describe('minBy', () => {
     it('should return the min value', () => {
-      const collection: Item[] = [{name: 'a', value: 1}, {name: 'b', value: 2}, {name: 'c', value: 3}, {name: 'd', value: 4}, {name: 'e', value: 5}]
+      const collection: Item[] = [
+        {name: 'a', value: 1},
+        {name: 'b', value: 2},
+        {name: 'c', value: 3},
+        {name: 'd', value: 4},
+        {name: 'e', value: 5},
+      ]
       expect(minBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'a', value: 1})
     })
 
     it('should return the first min value', () => {
-      const collection: Item[] = [{name: 'a', value: 5}, {name: 'b', value: 3}, {name: 'c', value: 1}, {name: 'd', value: 3}, {name: 'e', value: 1}]
+      const collection: Item[] = [
+        {name: 'a', value: 5},
+        {name: 'b', value: 3},
+        {name: 'c', value: 1},
+        {name: 'd', value: 3},
+        {name: 'e', value: 1},
+      ]
       expect(minBy(collection, (item: Item) => item.value)).to.deep.equal({name: 'c', value: 1})
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,11 +2200,6 @@ buffer-equal-constant-time@1.0.1:
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
 builtin-modules@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
@@ -5082,19 +5077,6 @@ sort-package-json@^2.10.1:
     sort-object-keys "^1.1.3"
     tinyglobby "^0.2.9"
 
-source-map-support@^0.5.21:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
 spdx-correct@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
@@ -5369,13 +5351,6 @@ tslib@^2.0.3, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
-tslog@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/tslog/-/tslog-3.3.4.tgz#083197a908c97b3b714a0576b9dac293f223f368"
-  integrity sha512-N0HHuHE0e/o75ALfkioFObknHR5dVchUad4F0XyFf3gXJYB++DewEzwGI/uIOM216E5a43ovnRNEeQIq9qgm4Q==
-  dependencies:
-    source-map-support "^0.5.21"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This pull request involves significant changes to the logging mechanism across various files. The primary change is the removal of the `tslog` library and the introduction of a custom `Logger` and `NullLogger` implementation. The most important changes include updates to the `GetBatchRuns` command, exporter classes, and store classes to use the new logging system.

### Logging System Update:
* Removed `tslog` dependency from `package.json` and replaced it with a custom `Logger` and `NullLogger` implementation in `src/util.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24) [[2]](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R1-R15)

### Command Updates:
* Updated `src/commands/get-batch-runs.ts` to replace `tslog` with the new logging system and modified logging calls to use `this.log` and `this.warn` methods. [[1]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81L3) [[2]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81L40-R52) [[3]](diffhunk://#diff-d28d778390c0365007946cda235cb005e39717fdcfc42baa6e8f90e7a50b0c81L83-R85)

### Exporter Classes:
* Modified constructors and logging calls in `BigqueryExporter`, `CompositExporter`, and `LocalExporter` to use the new `Logger` and `NullLogger`. [[1]](diffhunk://#diff-a0bec27641c1f7506777bce3bdce95f830bf58f63de9b8ba87fd8b60f10ac843L6-R9) [[2]](diffhunk://#diff-7d8d145470426dd4bc41f388645ba5ab26ee12872c3cfcab36d714499209a883L1-R3)R1, [[3]](diffhunk://#diff-2dc7d819e90984e5e488b176172f6f11870b3fe68b2b4bcd0b104a2790ca3b7fL3-R6)

### Store Classes:
* Updated `GcsStore`, `LocalStore`, and `NullStore` to use the new logging system, including changes to constructors and log method calls. [[1]](diffhunk://#diff-9e9531d666e8bb821d60202debe4c4681f5e10c172e77c2345a8382945d618c8L3-R19) [[2]](diffhunk://#diff-fb7d392fd748aa0de5329fe53fd7418eaf3606914b581f5a483b6da324bc7262L3-R13) [[3]](diffhunk://#diff-e2669b01743480885a7dd3b4ff6beedf7f87961b180cf555d4ca23030b25ca0dL1-R17)

### Client and Utility Updates:
* Updated `MagicPodClient` to replace `tslog` with the new logging system and adjusted logging calls accordingly. [[1]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L1-R1)R1, [[2]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L64-R69) [[3]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249R125-R128) [[4]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L139-R141) [[5]](diffhunk://#diff-349efea4a6fdc92292746eb1dc967290a799b86301c825a75f2308e458511249L151-R152)
* Added `Logger` and `NullLogger` implementations in `src/util.ts`.