### PR TITLE
ci: ignore major version updates for specific dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,39 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    ignore:
+      - dependency-name: "@oclif/core"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "@oclif/plugin-help"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "@oclif/prettier-config"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "@oclif/test"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "@types/chai"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "@types/mocha"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "chai"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-oclif"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-oclif-typescript"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-prettier"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "mocha"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "oclif"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "ts-node"
+        update-type: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-type: ["version-update:semver-major"]
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` file to ignore major version updates for several dependencies. The most important changes are as follows:

Dependency update management:

* Added rules to ignore major version updates for various dependencies including `@oclif/core`, `@oclif/plugin-help`, `@oclif/prettier-config`, `@oclif/test`, `@types/chai`, `@types/mocha`, `@types/node`, `chai`, `eslint`, `eslint-config-oclif`, `eslint-config-oclif-typescript`, `eslint-config-prettier`, `mocha`, `oclif`, `ts-node`, and `typescript` (`[.github/dependabot.ymlR10-R42](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R42)`).