### PR TITLE
ci: fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,37 +9,37 @@ updates:
       include: "scope"
     ignore:
       - dependency-name: "@oclif/core"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@oclif/plugin-help"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@oclif/prettier-config"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@oclif/test"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/chai"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/mocha"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/node"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "chai"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "eslint"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-config-oclif"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-config-oclif-typescript"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-config-prettier"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "mocha"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "oclif"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "ts-node"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
-        update-type: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/dependabot.yml` file to correct the key used for specifying update types. The change ensures that the correct key `update-types` is used instead of the incorrect `update-type`.

Changes in `.github/dependabot.yml`:

* Corrected the key from `update-type` to `update-types` for multiple dependencies to ensure proper configuration of version update types.