### PR TITLE
chore: change Dependabot update schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "build"
       include: "scope"
@@ -43,7 +43,7 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This pull request modifies the Dependabot configuration to adjust the update schedules for dependencies. The changes reduce the frequency of updates from weekly to monthly for both `npm` and `devcontainers` ecosystems.

Dependabot configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6): Changed the update schedule for `npm` dependencies from weekly to monthly.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L46-R46): Changed the update schedule for `devcontainers` dependencies from weekly to monthly.