### PR TITLE
chore: simplify Dependabot ignore list by allowing all major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,37 +8,7 @@ updates:
       prefix: "build"
       include: "scope"
     ignore:
-      - dependency-name: "@oclif/core"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@oclif/plugin-help"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@oclif/prettier-config"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@oclif/test"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/chai"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/mocha"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "chai"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "eslint"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "eslint-config-oclif"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "eslint-config-oclif-typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "eslint-config-prettier"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "mocha"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "oclif"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "ts-node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "typescript"
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "devcontainers"
     directory: "/"


### PR DESCRIPTION
This pull request modifies the `.github/dependabot.yml` file to simplify the configuration for ignoring major version updates. The change replaces a list of specific dependencies with a wildcard to apply the same rule to all dependencies.

Configuration simplification:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L11-R11): Replaced the explicit list of dependencies ignored for major version updates with a wildcard (`*`), ensuring that all dependencies are covered by the same rule. This reduces the need for maintaining a long list of dependency names.