### PR TITLE
chore: update version to 0.10.3 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magicpod-analyzer",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Export MagicPod test data for analyzing.",
   "author": "Takeshi Kishi",
   "bin": {


### PR DESCRIPTION
This pull request includes a version bump for the `magicpod-analyzer` package. The version has been updated from `0.10.2` to `0.10.3` in the `package.json` file.