### PR TITLE
chore: update version to 0.10.4 in package.json and README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@ $ npm install -g magicpod-analyzer
 $ magicpod-analyzer COMMAND
 running command...
 $ magicpod-analyzer (--version)
-magicpod-analyzer/0.10.2 linux-arm64 node-v22.15.0
+magicpod-analyzer/0.10.4 linux-arm64 node-v22.15.0
 $ magicpod-analyzer --help [COMMAND]
 USAGE
   $ magicpod-analyzer COMMAND
@@ -55,7 +55,7 @@ EXAMPLES
   $ magicpod-analyzer get-batch-runs
 ```
 
-_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.2/src/commands/get-batch-runs.ts)_
+_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.4/src/commands/get-batch-runs.ts)_
 
 ## `magicpod-analyzer help [COMMAND]`
 
@@ -75,7 +75,7 @@ DESCRIPTION
   Display help for magicpod-analyzer.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.28/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.32/src/commands/help.ts)_
 <!-- commandsstop -->
 
 ## 概要と仕組み

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install -g magicpod-analyzer
 $ magicpod-analyzer COMMAND
 running command...
 $ magicpod-analyzer (--version)
-magicpod-analyzer/0.10.2 linux-arm64 node-v22.15.0
+magicpod-analyzer/0.10.4 linux-arm64 node-v22.15.0
 $ magicpod-analyzer --help [COMMAND]
 USAGE
   $ magicpod-analyzer COMMAND
@@ -57,7 +57,7 @@ EXAMPLES
   $ magicpod-analyzer get-batch-runs
 ```
 
-_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.2/src/commands/get-batch-runs.ts)_
+_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.4/src/commands/get-batch-runs.ts)_
 
 ## `magicpod-analyzer help [COMMAND]`
 
@@ -77,5 +77,5 @@ DESCRIPTION
   Display help for magicpod-analyzer.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.28/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.2.32/src/commands/help.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magicpod-analyzer",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Export MagicPod test data for analyzing.",
   "author": "Takeshi Kishi",
   "bin": {


### PR DESCRIPTION
This pull request updates the version of the `magicpod-analyzer` tool to `0.10.4` and ensures that corresponding documentation and metadata reflect this change. The updates include modifications to version references in the `README` files, links to updated source code, and the `package.json` file.

### Version Updates:

* Updated the tool version from `0.10.2` to `0.10.4` in the `README.ja.md` file under the `$ npm install -g magicpod-analyzer` section.
* Updated the tool version from `0.10.2` to `0.10.4` in the `README.md` file under the `$ npm install -g magicpod-analyzer` section.
* Updated the `package.json` file to reflect the new version `0.10.4`.

### Documentation Links:

* Updated the link to the `get-batch-runs.ts` source file in `README.ja.md` to point to the version `0.10.4`.
* Updated the link to the `get-batch-runs.ts` source file in `README.md` to point to the version `0.10.4`.

### Dependency Reference:

* Updated the reference to the `@oclif/plugin-help` dependency in both `README.ja.md` and `README.md` to reflect the new version `6.2.32`. [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L78-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R80)