### PR TITLE
chore: update version to 0.10.5 in package.json and README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,7 +21,7 @@ $ npm install -g magicpod-analyzer
 $ magicpod-analyzer COMMAND
 running command...
 $ magicpod-analyzer (--version)
-magicpod-analyzer/0.10.4 linux-arm64 node-v22.15.0
+magicpod-analyzer/0.10.5 linux-arm64 node-v22.15.0
 $ magicpod-analyzer --help [COMMAND]
 USAGE
   $ magicpod-analyzer COMMAND
@@ -55,7 +55,7 @@ EXAMPLES
   $ magicpod-analyzer get-batch-runs
 ```
 
-_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.4/src/commands/get-batch-runs.ts)_
+_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.5/src/commands/get-batch-runs.ts)_
 
 ## `magicpod-analyzer help [COMMAND]`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install -g magicpod-analyzer
 $ magicpod-analyzer COMMAND
 running command...
 $ magicpod-analyzer (--version)
-magicpod-analyzer/0.10.4 linux-arm64 node-v22.15.0
+magicpod-analyzer/0.10.5 linux-arm64 node-v22.15.0
 $ magicpod-analyzer --help [COMMAND]
 USAGE
   $ magicpod-analyzer COMMAND
@@ -57,7 +57,7 @@ EXAMPLES
   $ magicpod-analyzer get-batch-runs
 ```
 
-_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.4/src/commands/get-batch-runs.ts)_
+_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.5/src/commands/get-batch-runs.ts)_
 
 ## `magicpod-analyzer help [COMMAND]`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magicpod-analyzer",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Export MagicPod test data for analyzing.",
   "author": "Takeshi Kishi",
   "bin": {


### PR DESCRIPTION
This pull request updates the project version from `0.10.4` to `0.10.5` and reflects this version bump in both the codebase and documentation. No functional or code logic changes are included.

Version update:

* Bumped the version in `package.json` from `0.10.4` to `0.10.5`.

Documentation updates:

* Updated the version number in the usage examples in both `README.md` and `README.ja.md` to `0.10.5`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L24-R24)
* Updated links to the `get-batch-runs.ts` source file in both `README.md` and `README.ja.md` to point to the new version (`v0.10.5`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R60) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L58-R58)