### PR TITLE
chore: update onRelease workflow to use yarn for npm publishing

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [released]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,10 +16,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn
       - run: yarn build
       - run: yarn prepack
-      - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+      - run: yarn npm publish
       - run: yarn postpack


### PR DESCRIPTION
This pull request updates the release workflow configuration in `.github/workflows/onRelease.yml` to improve security and streamline the npm publishing process. The main changes involve adjusting permissions and modifying the npm publish step.

**Workflow permissions and npm publish process:**

* Added explicit workflow permissions, granting `id-token: write` and `contents: read` to enhance security and enable future use of OpenID Connect authentication.
* Updated the Node.js setup step to specify the npm registry URL via `registry-url`, ensuring correct authentication and publishing to npm.
* Replaced the `JS-DevTools/npm-publish` GitHub Action with a direct `yarn npm publish` command, simplifying the publish process and reducing external dependencies.