### PR TITLE
chore: update version to 0.10.6 in package.json and README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@ MagicPodのテスト実行データを分析用に出力します. [CIAnalyzer](
 [![Downloads/week](https://img.shields.io/npm/dw/magicpod-analyzer.svg)](https://npmjs.org/package/magicpod-analyzer)
 
 > [!WARNING]
-> このパッケージは2025年10月1日を目処にアーカイブ予定です。以降の保守は行われません。ご利用中の方は代替手段をご検討ください。
+> このパッケージは2025年10月1日にアーカイブされました。以降の保守は行われません。ご利用中の方は代替手段をご検討ください。
 
 <!-- toc -->
 * [使い方](#usage)
@@ -21,7 +21,7 @@ $ npm install -g magicpod-analyzer
 $ magicpod-analyzer COMMAND
 running command...
 $ magicpod-analyzer (--version)
-magicpod-analyzer/0.10.5 linux-arm64 node-v22.15.0
+magicpod-analyzer/0.10.6 linux-arm64 node-v22.15.0
 $ magicpod-analyzer --help [COMMAND]
 USAGE
   $ magicpod-analyzer COMMAND
@@ -55,7 +55,7 @@ EXAMPLES
   $ magicpod-analyzer get-batch-runs
 ```
 
-_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.5/src/commands/get-batch-runs.ts)_
+_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.6/src/commands/get-batch-runs.ts)_
 
 ## `magicpod-analyzer help [COMMAND]`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Export MagicPod test data for analyzing. Inspired by [CIAnalyzer](https://github
 [日本語版はこちら](./README.ja.md)
 
 > [!WARNING]
-> This package is scheduled to be archived around October 1, 2025. It will no longer be maintained. Please consider migrating to an alternative if you are using it.
+> This package has already been archived as of October 1, 2025. It is no longer maintained. Please consider migrating to an alternative if you are using it.
 
 <!-- toc -->
 * [Usage](#usage)
@@ -23,7 +23,7 @@ $ npm install -g magicpod-analyzer
 $ magicpod-analyzer COMMAND
 running command...
 $ magicpod-analyzer (--version)
-magicpod-analyzer/0.10.5 linux-arm64 node-v22.15.0
+magicpod-analyzer/0.10.6 linux-arm64 node-v22.15.0
 $ magicpod-analyzer --help [COMMAND]
 USAGE
   $ magicpod-analyzer COMMAND
@@ -57,7 +57,7 @@ EXAMPLES
   $ magicpod-analyzer get-batch-runs
 ```
 
-_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.5/src/commands/get-batch-runs.ts)_
+_See code: [src/commands/get-batch-runs.ts](https://github.com/takeyaqa/magicpod-analyzer/blob/v0.10.6/src/commands/get-batch-runs.ts)_
 
 ## `magicpod-analyzer help [COMMAND]`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magicpod-analyzer",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Export MagicPod test data for analyzing.",
   "author": "Takeshi Kishi",
   "bin": {


### PR DESCRIPTION
This pull request updates the documentation and package metadata to reflect the archiving of the `magicpod-analyzer` project as of October 1, 2025, and increments the version to `0.10.6`. The changes ensure that users are clearly informed about the project's archived status and provide accurate version references in documentation and metadata.

Documentation updates:

* Updated both `README.md` and `README.ja.md` to state that the package has already been archived as of October 1, 2025, and is no longer maintained, instead of saying it is scheduled for archival. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L11-R11)
* Updated version references in usage examples and code links in both `README.md` and `README.ja.md` from `0.10.5` to `0.10.6`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R60) [[3]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L24-R24) [[4]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L58-R58)

Package metadata:

* Bumped the package version in `package.json` from `0.10.5` to `0.10.6`.