### PR TITLE
docs: update warning to caution in README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@ MagicPodのテスト実行データを分析用に出力します. [CIAnalyzer](
 [![Version](https://img.shields.io/npm/v/magicpod-analyzer.svg)](https://npmjs.org/package/magicpod-analyzer)
 [![Downloads/week](https://img.shields.io/npm/dw/magicpod-analyzer.svg)](https://npmjs.org/package/magicpod-analyzer)
 
-> [!WARNING]
+> [!CAUTION]
 > このパッケージは2025年10月1日にアーカイブされました。以降の保守は行われません。ご利用中の方は代替手段をご検討ください。
 
 <!-- toc -->

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Export MagicPod test data for analyzing. Inspired by [CIAnalyzer](https://github
 
 [日本語版はこちら](./README.ja.md)
 
-> [!WARNING]
+> [!CAUTION]
 > This package has already been archived as of October 1, 2025. It is no longer maintained. Please consider migrating to an alternative if you are using it.
 
 <!-- toc -->


### PR DESCRIPTION
This pull request updates the deprecation notice in the documentation to use a more appropriate callout style. The warning callout has been changed from "WARNING" to "CAUTION" in both the English and Japanese README files.

Documentation updates:

* Changed the callout from `[!WARNING]` to `[!CAUTION]` in the deprecation notice in `README.md` and `README.ja.md` to better reflect the nature of the message. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R12) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L10-R10)