### PR TITLE
chore: update onRelease workflow to use 'yarn publish' instead of 'yarn npm publish'

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -20,5 +20,5 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn prepack
-      - run: yarn npm publish
+      - run: yarn publish
       - run: yarn postpack


### PR DESCRIPTION
This pull request makes a small update to the release workflow by changing the publish command. The workflow now uses the standard `yarn publish` command instead of `yarn npm publish` to publish packages.

- [`.github/workflows/onRelease.yml`](diffhunk://#diff-07ad11b4716ea9cf0395ab663324e2ec514bd862242160a44ce12856afcc87fcL23-R23): Replaced `yarn npm publish` with `yarn publish` in the release workflow.