### PR TITLE
chore: update onRelease workflow to use 'npm publish' instead of 'yarn publish'

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -17,8 +17,9 @@ jobs:
         with:
           node-version: latest
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest
       - run: yarn
       - run: yarn build
       - run: yarn prepack
-      - run: yarn publish --non-interactive
+      - run: npm publish
       - run: yarn postpack


### PR DESCRIPTION
This pull request updates the release workflow to use the latest version of npm and switches the package publishing command from yarn to npm. These changes help ensure compatibility with the latest npm features and improve the reliability of the publishing process.

Release workflow updates:

* Added a step to install the latest npm globally before running build and publish commands in `.github/workflows/onRelease.yml`.
* Replaced `yarn publish` with `npm publish` for publishing packages, aligning the workflow with standard npm publishing practices.